### PR TITLE
doudesu: remove class in status tr tag

### DIFF
--- a/doudesu/core/doudesu.py
+++ b/doudesu/core/doudesu.py
@@ -143,7 +143,7 @@ class Doujindesu(ImageToPDFConverter):
             author=soup.find("tr", {"class": "pages"}).a.text.strip(),
             type=soup.find("tr", {"class": "magazines"}).a.text.strip(),
             score=float(soup.find("div", {"class": "rating-prc"}).text.strip()),
-            status=soup.find("tr", {"class": ""}).a.text.strip(),
+            status=soup.find("tr").a.text.strip(),
             chapter_urls=self.get_all_chapters(),
         )
 


### PR DESCRIPTION
this fix error AttributeError: 'NoneType' object has no attribute 'a' class tr status is none so remove that for fix error while choose manga :b

Signed-off-by: picasso09 <picasso09DV@proton.me>

Date:      Thu Apr 10 20:23:27 2025 +0700
Change-Id: 06000232450972450fb3bf17efd4faea050b6b33